### PR TITLE
Update artist and track training data scripts and README for consistency

### DIFF
--- a/sql/backtest/README.md
+++ b/sql/backtest/README.md
@@ -29,7 +29,7 @@ The backtest datasets typically contain:
 | Column | Description |
 |--------|-------------|
 | id | Primary key, auto-incrementing |
-| artist_id | Reference to the artist |
+| cm_artist_id | Reference to the artist |
 | sp_streams_date | Date of the streaming data point |
 | monthly_listeners | Count of monthly listeners for that date |
 | created_at | Timestamp when the record was created |
@@ -47,14 +47,18 @@ The backtest datasets typically contain:
 ### Current Dataset Statistics:
 
 **Artist Data:**
-- 1656 unique artists in the training dataset
-- Reduced from 2212 artists in the source data
+- 1,565 unique artists in the final training dataset
+- Initially 1,656 artists after filtering from 2,212 in the source data
 - Reduction due to filtering out artists without sufficient training data (90+ days) or validation data (730+ days)
 
 **Track Data:**
-- 9,974 unique tracks in the training dataset
-- Reduced from 24,188 tracks in the source data
-- Reduction due to filtering out tracks without sufficient training data (90+ days) or validation data (730+ days)
+- Initial filtering: 9,974 unique tracks from 24,188 in the source data
+- Final dataset: 8,318 unique tracks across 1,565 unique artists
+- Further reduction due to removing orphaned tracks (tracks without corresponding artist data)
+
+## Data Consistency
+
+To ensure that forecasting models can be run properly, orphaned tracks that didn't have corresponding artists in the artist training dataset were removed. This data cleanup ensures that for every track in the dataset, we also have artist-level data available.
 
 ## Usage
 

--- a/sql/backtest/artist_training_data_creation.sql
+++ b/sql/backtest/artist_training_data_creation.sql
@@ -9,7 +9,7 @@
 -- backtest_artist_daily_training_data
 -- -------------------------------------------------------------------------
 -- id                  - Primary key, auto-incrementing
--- artist_id           - Reference to the artist
+-- cm_artist_id        - Reference to the artist
 -- sp_streams_date     - Date of the streaming data point
 -- monthly_listeners   - Count of monthly listeners for that date
 -- created_at          - Timestamp when the record was created
@@ -24,23 +24,23 @@
 -- 2. Artists must have at least 730 days of data between April 1, 2023 and March 31, 2025 (validation period)
 
 -- For qualified artists, we copy:
---   - artist_id
+--   - cm_artist_id
 --   - sp_streams_date
 --   - monthly_listeners
 -- But only for dates before April 1, 2023 (the training period)
 
-INSERT INTO backtest_artist_daily_training_data (artist_id, sp_streams_date, monthly_listeners)
+INSERT INTO backtest_artist_daily_training_data (cm_artist_id, sp_streams_date, monthly_listeners)
 SELECT
-  artist_id,
+  cm_artist_id,
   sp_streams_date,
   monthly_listeners
 FROM artist_monthly_listeners_history
 WHERE
   sp_streams_date < '2023-04-01'
-  AND artist_id IN (
-    SELECT artist_id
+  AND cm_artist_id IN (
+    SELECT cm_artist_id
     FROM artist_monthly_listeners_history
-    GROUP BY artist_id
+    GROUP BY cm_artist_id
     HAVING
       COUNT(*) FILTER (WHERE sp_streams_date < '2023-04-01') >= 90 AND
       COUNT(*) FILTER (WHERE sp_streams_date BETWEEN '2023-04-01' AND '2025-03-31') >= 730
@@ -49,7 +49,14 @@ WHERE
 -- =========================================================================
 -- RESULTS SUMMARY
 -- =========================================================================
--- After applying the data validation criteria, the final training dataset
--- contains 1656 unique artists, down from 2212 in the source data.
+-- Initial filtering:
+-- After applying the data validation criteria, the initial training dataset
+-- contained 1,656 unique artists, down from 2,212 in the source data.
 -- This reduction occurred due to eliminating artists without sufficient
--- training data (90+ days) or validation data (730+ days). 
+-- training data (90+ days) or validation data (730+ days).
+--
+-- Data consistency:
+-- After removal of artists without corresponding tracks in the track training
+-- dataset, the final count is 1,565 unique artists.
+-- This ensures that all artists in the dataset have associated track data
+-- available for forecasting models. 

--- a/sql/backtest/track_training_data_creation.sql
+++ b/sql/backtest/track_training_data_creation.sql
@@ -59,7 +59,18 @@ WHERE
 -- =========================================================================
 -- RESULTS SUMMARY
 -- =========================================================================
--- After applying the data validation criteria, the final training dataset
--- contains 9,974 unique tracks, down from 24,188 in the source data.
+-- Initial filtering:
+-- After applying the data validation criteria, the initial training dataset
+-- contained 9,974 unique tracks, down from 24,188 in the source data.
 -- This reduction occurred due to eliminating tracks without sufficient
--- training data (90+ days) or validation data (730+ days). 
+-- training data (90+ days) or validation data (730+ days).
+--
+-- Orphaned track cleanup:
+-- Additional cleanup was performed to remove orphaned tracks that didn't have
+-- corresponding artist data in the artist training dataset. This ensures
+-- that when running forecasting models, we have both artist and track data
+-- available for all entities.
+--
+-- Final dataset:
+-- 8,318 unique tracks across 1,565 unique artists
+-- This represents a further reduction of 1,656 tracks from the initial filtered set. 


### PR DESCRIPTION
- Renamed `artist_id` to `cm_artist_id` in SQL scripts to ensure uniformity across datasets.
- Enhanced documentation in SQL scripts and README with detailed statistics on dataset filtering and cleanup processes.
- Clarified the final counts of unique artists and tracks after data validation and orphaned track removal.